### PR TITLE
BUG: Kotlin Bug (swift works)

### DIFF
--- a/crates/lemon_meringue_pie/src/lib.rs
+++ b/crates/lemon_meringue_pie/src/lib.rs
@@ -4,6 +4,7 @@ pub mod prelude {
     pub use crate::models::*;
 
     pub(crate) use chef::prelude::*;
+    pub(crate) use common::prelude::*;
     pub(crate) use farm::prelude::*;
     pub(crate) use lemon_filling::prelude::*;
     pub(crate) use meringue::prelude::*;

--- a/crates/lemon_meringue_pie/src/models.rs
+++ b/crates/lemon_meringue_pie/src/models.rs
@@ -2,19 +2,19 @@ use std::sync::Arc;
 
 use crate::prelude::*;
 
-// #[derive(Clone, Debug, PartialEq, Eq, Default)]
-// pub struct PieID(Uuid);
+#[derive(Clone, Debug, PartialEq, Eq, Default)]
+pub struct PieBatchID(BatchID);
 
-// uniffi::custom_type!(PieID, Uuid, {
-//     remote,
-//     from_custom: |pie_id| pie_id.0,
-//     try_into_custom: |uuid| Ok(PieID(uuid))
-// });
+uniffi::remote_type!(BatchID, farm);
+uniffi::custom_type!(PieBatchID, BatchID, {
+    from_custom: |batch_id| batch_id.0,
+    try_into_custom: |uuid| Ok(PieBatchID(uuid))
+});
 
-// #[uniffi::export]
-// pub fn new_pie_id_default() -> PieID {
-//     ApplianceID::default()
-// }
+#[uniffi::export]
+pub fn new_pie_batch_id_random() -> PieBatchID {
+    PieBatchID(new_batch_id_random())
+}
 
 /// Lemon Meringue Pie is the most tasty of pies, [here is a recipe].
 ///
@@ -26,6 +26,7 @@ use crate::prelude::*;
 /// [recipe]: https://www.bbc.co.uk/food/recipes/marys_lemon_meringue_pie_02330
 #[derive(Default, Clone, Debug, PartialEq, Eq, uniffi::Record)]
 pub struct LemonMeringuePie {
+    pub batch: PieBatchID,
     pub lemon_filling: LemonFilling,
     pub meringue: Meringue,
     pub pastry: Pastry,
@@ -39,6 +40,7 @@ impl LemonMeringuePie {
         pastry: Pastry,
     ) -> Self {
         Self {
+            batch: new_pie_batch_id_random(),
             lemon_filling,
             meringue,
             pastry,

--- a/crates/lemon_meringue_pie/tests/bindings/pie_baking.swift
+++ b/crates/lemon_meringue_pie/tests/bindings/pie_baking.swift
@@ -8,6 +8,8 @@ func test() {
   let kitchen = kitchenStockWith(produce: produce)
   let pie = bakeLemonMeringuePie(chef: chef, kitchen: kitchen)
 
+  assert(pie.batch != newPieBatchIdRandom())
+
   assert(chef.balance() == 50)
   assert(farm.balance() == 200)
 


### PR DESCRIPTION
This is a bug, do not merge. I opened it as a DRAFT PR just to be able to show this bug to @bendk

N.B. Kotlin bug only, works in Swift! Bug due to in Kotlin there are many different RustBuffers, one per crate

```sh
error: type mismatch: inferred type is com.sajjon.farm.RustBuffer.ByValue but com.sajjon.common.RustBuffer.ByValue was expected uniffiRustCall() { _status ->
```

<img width="1624" alt="Screenshot 2024-05-21 at 10 15 53" src="https://github.com/Sajjon/lemon-merringue-pie/assets/864410/1302e7b4-3665-4dd3-8ba1-3867b1b8297f">

